### PR TITLE
Skip e2e tests in Jest

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -40,6 +40,7 @@ const customJestConfig = {
     '/functions/api/test.js', // Skip non-test files with "test" in the name
     '/.next/',
     '/out/',
+    '/e2e/',
   ],
   collectCoverageFrom: [
     'src/**/*.{js,jsx,ts,tsx}',

--- a/src/lib/email-service.ts
+++ b/src/lib/email-service.ts
@@ -134,7 +134,8 @@ export async function sendContactFormEmail(
     });
 
     // Send a copy to the user if requested
-    if (sendUserCopy && validateEmail(data.email)) {
+    const emailValidation = validateEmail(data.email)
+    if (sendUserCopy && emailValidation.valid) {
       try {
         // Prepare user confirmation template data
         const userTemplateData: EmailTemplateData = {
@@ -180,14 +181,6 @@ export async function sendContactFormEmail(
       message: error instanceof Error ? error.message : 'Unknown error sending email'
     };
   }
-}
-
-/**
- * Validate email address format
- */
-export function validateEmail(email: string): boolean {
-  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-  return emailRegex.test(email);
 }
 
 /**


### PR DESCRIPTION
## Summary
- ignore `e2e` folder so Playwright isn't required for unit tests

## Testing
- `npm run lint`
- `npm test --silent`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved email validation when sending a copy of the contact form email to users, ensuring more comprehensive checks and clearer validation feedback.
- **Chores**
  - Updated test configuration to exclude end-to-end tests from standard test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->