### PR TITLE
Add Open Graph metadata to pages

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -35,6 +35,33 @@ import { EducationSection } from "@/components/education/education-section";
 export const metadata: Metadata = {
   title: "About Me | Jacob Barkin",
   description: "Learn more about Jacob Barkin, my background, education, and skills in technology and financial education.",
+  alternates: {
+    canonical: "https://jacobbarkin.com/about",
+  },
+  openGraph: {
+    title: "About Me | Jacob Barkin",
+    description: "Learn more about Jacob Barkin, my background, education, and skills in technology and financial education.",
+    url: "https://jacobbarkin.com/about",
+    siteName: "Jacob Barkin Portfolio",
+    images: [
+      {
+        url: "/images/Updated logo.png",
+        width: 800,
+        height: 600,
+        alt: "Jacob Barkin Logo",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "About Me | Jacob Barkin",
+    description: "Learn more about Jacob Barkin, my background, education, and skills in technology and financial education.",
+    images: ["/images/Updated logo.png"],
+    creator: "@jacobbarkin",
+    site: "@jacobbarkin",
+  },
 };
 
 export default function AboutPage() {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -16,6 +16,33 @@ export const revalidate = false;
 export const metadata: Metadata = {
   title: "Contact | Jacob Barkin",
   description: "Get in touch with Jacob Barkin for collaboration, questions, or just to say hello.",
+  alternates: {
+    canonical: "https://jacobbarkin.com/contact",
+  },
+  openGraph: {
+    title: "Contact | Jacob Barkin",
+    description: "Get in touch with Jacob Barkin for collaboration, questions, or just to say hello.",
+    url: "https://jacobbarkin.com/contact",
+    siteName: "Jacob Barkin Portfolio",
+    images: [
+      {
+        url: "/images/Updated logo.png",
+        width: 800,
+        height: 600,
+        alt: "Jacob Barkin Logo",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Contact | Jacob Barkin",
+    description: "Get in touch with Jacob Barkin for collaboration, questions, or just to say hello.",
+    images: ["/images/Updated logo.png"],
+    creator: "@jacobbarkin",
+    site: "@jacobbarkin",
+  },
 };
 
 export default function ContactPage() {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -40,9 +40,6 @@ export const metadata: Metadata = {
     telephone: true,
   },
   metadataBase: new URL("https://jacobbarkin.com"),
-  alternates: {
-    canonical: "/",
-  },
   icons: {
     icon: [
       { url: "/favicon.ico", sizes: "any" },
@@ -92,7 +89,6 @@ export const metadata: Metadata = {
   category: "technology",
   applicationName: "Jacob Barkin Portfolio",
   referrer: "origin-when-cross-origin",
-  keywords: ["Jacob Barkin", "Developer", "Technology Consulting", "Web Development", "Next.js", "Portfolio", "Technology", "Accessibility", "Public Transportation Research", "High School Student", "Kent Denver School", "Financial Education"],
 };
 
 export default function RootLayout({

--- a/src/app/macbook-pro-opencore/page.tsx
+++ b/src/app/macbook-pro-opencore/page.tsx
@@ -19,6 +19,33 @@ import { PageHero } from "@/components/ui/page-hero";
 export const metadata: Metadata = {
   title: "MacBook Pro OpenCore Project | Jacob Barkin",
   description: "How I revitalized my 2010 MacBook Pro by installing multiple macOS versions (10.7-12.0) using OpenCore bootloader.",
+  alternates: {
+    canonical: "https://jacobbarkin.com/macbook-pro-opencore",
+  },
+  openGraph: {
+    title: "MacBook Pro OpenCore Project | Jacob Barkin",
+    description: "How I revitalized my 2010 MacBook Pro by installing multiple macOS versions (10.7-12.0) using OpenCore bootloader.",
+    url: "https://jacobbarkin.com/macbook-pro-opencore",
+    siteName: "Jacob Barkin Portfolio",
+    images: [
+      {
+        url: "/images/Updated logo.png",
+        width: 800,
+        height: 600,
+        alt: "Jacob Barkin Logo",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "MacBook Pro OpenCore Project | Jacob Barkin",
+    description: "How I revitalized my 2010 MacBook Pro by installing multiple macOS versions (10.7-12.0) using OpenCore bootloader.",
+    images: ["/images/Updated logo.png"],
+    creator: "@jacobbarkin",
+    site: "@jacobbarkin",
+  },
 };
 
 export default function MacbookProOpencorePage() {

--- a/src/app/macos-apple-tv/page.tsx
+++ b/src/app/macos-apple-tv/page.tsx
@@ -19,6 +19,33 @@ import { PageHero } from "@/components/ui/page-hero";
 export const metadata: Metadata = {
   title: "Apple TV macOS Project | Jacob Barkin",
   description: "How I installed macOS on a 1st generation Apple TV, transforming it into a functional Mac computer.",
+  alternates: {
+    canonical: "https://jacobbarkin.com/macos-apple-tv",
+  },
+  openGraph: {
+    title: "Apple TV macOS Project | Jacob Barkin",
+    description: "How I installed macOS on a 1st generation Apple TV, transforming it into a functional Mac computer.",
+    url: "https://jacobbarkin.com/macos-apple-tv",
+    siteName: "Jacob Barkin Portfolio",
+    images: [
+      {
+        url: "/images/Updated logo.png",
+        width: 800,
+        height: 600,
+        alt: "Jacob Barkin Logo",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Apple TV macOS Project | Jacob Barkin",
+    description: "How I installed macOS on a 1st generation Apple TV, transforming it into a functional Mac computer.",
+    images: ["/images/Updated logo.png"],
+    creator: "@jacobbarkin",
+    site: "@jacobbarkin",
+  },
 };
 
 export default function MacOSAppleTVPage() {

--- a/src/app/portfolio-website/page.tsx
+++ b/src/app/portfolio-website/page.tsx
@@ -27,6 +27,33 @@ import { PageHero } from "@/components/ui/page-hero";
 export const metadata: Metadata = {
   title: "Portfolio Website | Jacob Barkin",
   description: "Learn about the development of my portfolio website built with Next.js, Tailwind CSS, and shadcn UI.",
+  alternates: {
+    canonical: "https://jacobbarkin.com/portfolio-website",
+  },
+  openGraph: {
+    title: "Portfolio Website | Jacob Barkin",
+    description: "Learn about the development of my portfolio website built with Next.js, Tailwind CSS, and shadcn UI.",
+    url: "https://jacobbarkin.com/portfolio-website",
+    siteName: "Jacob Barkin Portfolio",
+    images: [
+      {
+        url: "/images/Updated logo.png",
+        width: 800,
+        height: 600,
+        alt: "Jacob Barkin Logo",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Portfolio Website | Jacob Barkin",
+    description: "Learn about the development of my portfolio website built with Next.js, Tailwind CSS, and shadcn UI.",
+    images: ["/images/Updated logo.png"],
+    creator: "@jacobbarkin",
+    site: "@jacobbarkin",
+  },
 };
 
 export default function PortfolioWebsitePage() {

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -16,6 +16,33 @@ import "./projects-fixed.css";
 export const metadata: Metadata = {
   title: "Projects | Jacob Barkin",
   description: "Explore Jacob Barkin's projects in technology, technology consulting, and public transportation research.",
+  alternates: {
+    canonical: "https://jacobbarkin.com/projects",
+  },
+  openGraph: {
+    title: "Projects | Jacob Barkin",
+    description: "Explore Jacob Barkin's projects in technology, technology consulting, and public transportation research.",
+    url: "https://jacobbarkin.com/projects",
+    siteName: "Jacob Barkin Portfolio",
+    images: [
+      {
+        url: "/images/Updated logo.png",
+        width: 800,
+        height: 600,
+        alt: "Jacob Barkin Logo",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Projects | Jacob Barkin",
+    description: "Explore Jacob Barkin's projects in technology, technology consulting, and public transportation research.",
+    images: ["/images/Updated logo.png"],
+    creator: "@jacobbarkin",
+    site: "@jacobbarkin",
+  },
 };
 
 // Project data

--- a/src/app/public-transportation/page.tsx
+++ b/src/app/public-transportation/page.tsx
@@ -26,6 +26,33 @@ export const revalidate = false;
 export const metadata: Metadata = {
   title: "Public Transportation Research | Jacob Barkin",
   description: "Explore my research on public transportation systems in Colorado, focusing on accessibility and sustainability.",
+  alternates: {
+    canonical: "https://jacobbarkin.com/public-transportation",
+  },
+  openGraph: {
+    title: "Public Transportation Research | Jacob Barkin",
+    description: "Explore my research on public transportation systems in Colorado, focusing on accessibility and sustainability.",
+    url: "https://jacobbarkin.com/public-transportation",
+    siteName: "Jacob Barkin Portfolio",
+    images: [
+      {
+        url: "/images/Updated logo.png",
+        width: 800,
+        height: 600,
+        alt: "Jacob Barkin Logo",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Public Transportation Research | Jacob Barkin",
+    description: "Explore my research on public transportation systems in Colorado, focusing on accessibility and sustainability.",
+    images: ["/images/Updated logo.png"],
+    creator: "@jacobbarkin",
+    site: "@jacobbarkin",
+  },
 };
 
 export default function PublicTransportationPage() {

--- a/src/app/raspberry-pi-homelab/page.tsx
+++ b/src/app/raspberry-pi-homelab/page.tsx
@@ -20,6 +20,33 @@ import { PageHero } from "@/components/ui/page-hero";
 export const metadata: Metadata = {
   title: "Raspberry Pi 5 Homelab | Jacob Barkin",
   description: "How I built a powerful homelab using a Raspberry Pi 5 with Docker containers, accessible from anywhere using Tailscale and Cloudflare Tunnels.",
+  alternates: {
+    canonical: "https://jacobbarkin.com/raspberry-pi-homelab",
+  },
+  openGraph: {
+    title: "Raspberry Pi 5 Homelab | Jacob Barkin",
+    description: "How I built a powerful homelab using a Raspberry Pi 5 with Docker containers, accessible from anywhere using Tailscale and Cloudflare Tunnels.",
+    url: "https://jacobbarkin.com/raspberry-pi-homelab",
+    siteName: "Jacob Barkin Portfolio",
+    images: [
+      {
+        url: "/images/Updated logo.png",
+        width: 800,
+        height: 600,
+        alt: "Jacob Barkin Logo",
+      },
+    ],
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Raspberry Pi 5 Homelab | Jacob Barkin",
+    description: "How I built a powerful homelab using a Raspberry Pi 5 with Docker containers, accessible from anywhere using Tailscale and Cloudflare Tunnels.",
+    images: ["/images/Updated logo.png"],
+    creator: "@jacobbarkin",
+    site: "@jacobbarkin",
+  },
 };
 
 export default function RaspberryPiHomelabPage() {


### PR DESCRIPTION
## Summary
- remove duplicate keywords field from layout
- add Open Graph and Twitter metadata to individual pages

## Testing
- `npm test`
- `npm run lint` *(shows warnings but completes)*